### PR TITLE
Add -f families option to filter-in matching algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ You can also hash items from the standard input like so:
 
     $ cat my_large_file.bin | omnihash
 
+You can pass multiple inputs at any time (ex, `omnihash *`).
+
+You can force string-hashing (not falling-back to files) with `-s`.
+
+You may limit the number of algorithms using the `-f` (*"family"*) option:
+
+    $ oh Hi -f sha2 -f sha5
+    SHA224:                7d5104ff2cee331a4586337ea64ab6a188e2b26aecae87227105dae1
+    SHA256:                3639efcd08abb273b1619e82e78c29a7df02c1051b1820e99fc395dcaa3326b8
+    SHA512:                45ca55ccaa72b98b86c697fdf73fd364d4815a586f76cd326f1785bb816ff7f1f88b46fb8448b19356ee788eb7d300b9392709a289428070b5810d9b5c2d440d
+
 You can filter for string matches using `-m`, like so:
 
     $ omnihash "correct horse battery staple" -m 9cc2
@@ -123,10 +134,6 @@ You can output in machine readable JSON with `-j`, like so:
     }
 
 It's aliased so you can actually just call `oh` if you're as lazy as I am.
-
-You can pass multiple inputs at any time (ex, `omnihash *`).
-
-You can force string-hashing with `-s`.
 
 You can also see the value for various CRC checks by using `-c`:
 

--- a/omnihash/omnihash.py
+++ b/omnihash/omnihash.py
@@ -102,7 +102,7 @@ def main(click_context, hashmes, s, v, c, m, j):
             stdin = click.get_binary_stream('stdin')
             bytechunks = iter(lambda: stdin.read(io.DEFAULT_BUFFER_SIZE), b'')
             if not j:
-                click.echo("Hashing " + click.style("standard input", bold=True) + "..")
+                click.echo("Hashing " + click.style("standard input", bold=True) + "..", err=True)
             results = produce_hashes(bytechunks, digesters, match=m)
         else:
             print(click_context.get_help())
@@ -126,7 +126,7 @@ def iterate_bytechunks(hashme, is_string=True, use_json=False):
     # URL
     if not is_string and validators.url(hashme):
         if not use_json:
-            click.echo("Hashing content of URL " + click.style("{}".format(hashme), bold=True) + "..")
+            click.echo("Hashing content of URL " + click.style("{}".format(hashme), bold=True) + "..", err=True)
         try:
             response = requests.get(hashme)
         except requests.exceptions.ConnectionError as e:
@@ -140,16 +140,16 @@ def iterate_bytechunks(hashme, is_string=True, use_json=False):
     elif os.path.exists(hashme) and not is_string:
         if os.path.isdir(hashme):
             if not use_json:
-                click.echo(click.style("Skipping", fg="yellow") + " directory " + "'" + hashme + "'..")
+                click.echo(click.style("Skipping", fg="yellow") + " directory " + "'" + hashme + "'..", err=True)
             return None
 
         if not use_json:
-            click.echo("Hashing file " + click.style("{}".format(hashme), bold=True) + "..")
+            click.echo("Hashing file " + click.style("{}".format(hashme), bold=True) + "..", err=True)
         bytechunks = FileIter(open(hashme, mode='rb'))
     # String
     else:
         if not use_json:
-            click.echo("Hashing string " + click.style("{}".format(hashme), bold=True) + "..")
+            click.echo("Hashing string " + click.style("{}".format(hashme), bold=True) + "..", err=True)
         bytechunks = (hashme.encode('utf-8'), )
 
     return bytechunks
@@ -208,7 +208,7 @@ def produce_hashes(bytechunks, digesters, match, use_json=False):
     if match:
         if not match_found:
             if not use_json:
-                click.echo(click.style("No matches", fg='red') + " found!")
+                click.echo(click.style("No matches", fg='red') + " found!", err=True)
 
     return results
 

--- a/omnihash/omnihash.py
+++ b/omnihash/omnihash.py
@@ -77,10 +77,13 @@ class FileIter(object):
 @click.option('-s', is_flag=True, default=False, help="Hash input as string, even if there is a file with that name.")
 @click.option('-v', is_flag=True, default=False, help="Show version and quit.")
 @click.option('-c', is_flag=True, default=False, help="Calculate CRCs as well.")
+@click.option('-f', is_flag=False, default=False, multiple=True,
+              help="Select one or more family of algorithms: "
+              "include only algos having TEXT (ci) in their names.")
 @click.option('-m', is_flag=False, default=False, help="Match input string.")
 @click.option('-j', is_flag=True, default=False, help="Output result in JSON format.")
 @click.pass_context
-def main(click_context, hashmes, s, v, c, m, j):
+def main(click_context, hashmes, s, v, c, f, m, j):
     """
     If there is a file at hashme, read and omnihash that file.
     Elif hashme is a string, omnihash that.
@@ -98,7 +101,7 @@ def main(click_context, hashmes, s, v, c, m, j):
     if not hashmes:
         # If no stdin, just help and quit.
         if not sys.stdin.isatty():
-            digesters = make_digesters(c)
+            digesters = make_digesters(f, c)
             stdin = click.get_binary_stream('stdin')
             bytechunks = iter(lambda: stdin.read(io.DEFAULT_BUFFER_SIZE), b'')
             if not j:
@@ -109,7 +112,7 @@ def main(click_context, hashmes, s, v, c, m, j):
             return
     else:
         for hashme in hashmes:
-            digesters = make_digesters(c)
+            digesters = make_digesters(f, c)
             bytechunks = iterate_bytechunks(hashme, s, j)
             if bytechunks:
                 results = produce_hashes(bytechunks, digesters, match=m, use_json=j)
@@ -155,17 +158,24 @@ def iterate_bytechunks(hashme, is_string=True, use_json=False):
     return bytechunks
 
 
-def make_digesters(include_CRCs=False):
+def _is_algo_in_families(algo_name, families):
+    """:param algo_name: make sure it is UPPER"""
+    return not families or any(f in algo_name for f in families)
+
+
+def make_digesters(families, include_CRCs=False):
     """
     Create and return a dictionary of all our active hash algorithms.
     """
+    families = set(f.upper() for f in families)
     digesters = OrderedDict()
 
     # Default Algos
     for algo in sorted(hashlib.algorithms_available):
         # algorithms_available can have duplicates
-        if algo.upper() not in digesters:
-            digesters[algo.upper()] = (hashlib.new(algo), lambda d: d.hexdigest())
+        aname = algo.upper()
+        if aname not in digesters and _is_algo_in_families(aname, families):
+            digesters[aname] = (hashlib.new(algo), lambda d: d.hexdigest())
 
     ## Append plugin digesters.
     digesters.update(known_digesters)
@@ -174,8 +184,10 @@ def make_digesters(include_CRCs=False):
     if include_CRCs:
         for name in sorted(crcmod._crc_definitions_by_name):
             crc_name = crcmod._crc_definitions_by_name[name]['name']
-            digesters[crc_name.upper()] = (crcmod.PredefinedCrc(crc_name),
-                                           lambda d: hex(d.crcValue))
+            aname = crc_name.upper()
+            if _is_algo_in_families(aname, families):
+                digesters[aname] = (crcmod.PredefinedCrc(crc_name),
+                                               lambda d: hex(d.crcValue))
 
     return digesters
 

--- a/omnihash/omnihash.py
+++ b/omnihash/omnihash.py
@@ -35,7 +35,8 @@ def intialize_plugins(plugin_group_name=PLUGIN_GROUP_NAME):
                 plugin_loader()
         except Exception as ex:
             click.echo('Failed LOADING plugin(%r@%s) due to: %s' % (
-                      ep, ep.dist, ex), err=1)
+                       ep, ep.dist, ex), err=1)
+
 
 # Plugin algos
 def plugin_sha3_digesters(include_CRCs=False):
@@ -45,6 +46,7 @@ def plugin_sha3_digesters(include_CRCs=False):
     known_digesters['SHA3_256'] = (sha3.SHA3256(), lambda d: d.hexdigest().decode("utf-8"))
     known_digesters['SHA3_384'] = (sha3.SHA3384(), lambda d: d.hexdigest().decode("utf-8"))
     known_digesters['SHA3_512'] = (sha3.SHA3512(), lambda d: d.hexdigest().decode("utf-8"))
+
 
 def plugin_pyblake2_digesters(include_CRCs=False):
     import pyblake2  # @UnresolvedImport
@@ -86,7 +88,6 @@ def main(click_context, hashmes, s, v, c, m, j):
 
     # Print version and quit
     if v:
-        import pkg_resources
         version = pkg_resources.require("omnihash")[0].version
         click.echo(version)
         return
@@ -115,6 +116,7 @@ def main(click_context, hashmes, s, v, c, m, j):
 
     if results and j:
         print(json.dumps(results, indent=4, sort_keys=True))
+
 
 def iterate_bytechunks(hashme, is_string=True, use_json=False):
     """
@@ -209,6 +211,7 @@ def produce_hashes(bytechunks, digesters, match, use_json=False):
                 click.echo(click.style("No matches", fg='red') + " found!")
 
     return results
+
 
 def echo(algo, digest, json=False):
     if not json:

--- a/tests/test.py
+++ b/tests/test.py
@@ -48,6 +48,29 @@ def test_omnihashfile():
     assert '941c986ff0f3e90543dc5e2a0687ee99b19bff67' in result.output
 
 
+def test_omnihashf():
+    runner = CliRunner()
+    result = runner.invoke(main, 'Hi -f sha2 -f SHA5'.split())
+    assert result.exit_code == 0
+    out = """
+  SHA224:                7d5104ff2cee331a4586337ea64ab6a188e2b26aecae87227105dae1
+  SHA256:                3639efcd08abb273b1619e82e78c29a7df02c1051b1820e99fc395dcaa3326b8
+  SHA512:                45ca55ccaa72b98b86c697fdf73fd364d4815a586f76cd326f1785bb816ff7f1f88b46fb8448b19356ee788eb7d300\
+b9392709a289428070b5810d9b5c2d440d
+"""
+    assert result.output.endswith(out)
+
+    result = runner.invoke(main, 'Hi -c -f sha2 -c -f ITU'.split())
+    assert result.exit_code == 0
+    out = """
+  SHA224:                7d5104ff2cee331a4586337ea64ab6a188e2b26aecae87227105dae1
+  SHA256:                3639efcd08abb273b1619e82e78c29a7df02c1051b1820e99fc395dcaa3326b8
+  CRC-8-ITU:             0xbe
+"""
+    print(out)
+    assert result.output.endswith(out)
+
+
 def test_omnihashs():
     runner = CliRunner()
     result = runner.invoke(main, ['hashme', 'LICENSE', '-s'])

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,19 +1,9 @@
-import glob
-import os
-import re
-import string
-import sys
+from omnihash.omnihash import main
 import unittest
-
-import nose
-from nose import case
-from nose.pyversion import unbound_method
-from nose import util
 
 import click
 from click.testing import CliRunner
 
-from omnihash.omnihash import main
 
 # Sanity
 def test_hello_world():
@@ -27,12 +17,14 @@ def test_hello_world():
     assert result.exit_code == 0
     assert result.output == 'Hello Peter!\n'
 
+
 # Main
 def test_empty():
     runner = CliRunner()
     result = runner.invoke(main)
     print(result.output)
     assert result.exit_code == 0
+
 
 def test_omnihash():
     runner = CliRunner()
@@ -41,11 +33,13 @@ def test_omnihash():
     assert result.exit_code == 0
     assert 'fb78992e561929a6967d5328f49413fa99048d06' in result.output
 
+
 def test_omnihash2():
     runner = CliRunner()
     result = runner.invoke(main, ['hashme', 'asdf'])
     assert result.exit_code == 0
     assert 'fb78992e561929a6967d5328f49413fa99048d06' in result.output
+
 
 def test_omnihashfile():
     runner = CliRunner()
@@ -53,11 +47,13 @@ def test_omnihashfile():
     assert result.exit_code == 0
     assert '941c986ff0f3e90543dc5e2a0687ee99b19bff67' in result.output
 
+
 def test_omnihashs():
     runner = CliRunner()
     result = runner.invoke(main, ['hashme', 'LICENSE', '-s'])
     assert result.exit_code == 0
     assert '0398ccd0f49298b10a3d76a47800d2ebecd49859' in result.output
+
 
 def test_omnihashcrc():
     runner = CliRunner()
@@ -67,23 +63,25 @@ def test_omnihashcrc():
     assert 'fb78992e561929a6967d5328f49413fa99048d06' in result.output
     assert '5d20a7c38be78000' in result.output
 
+
 def test_url():
     runner = CliRunner()
-    result = runner.invoke(main, ['hashme', 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png', '-c'])
+    result = runner.invoke(main, ['hashme', 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png', '-c'])    # noqa
     assert result.exit_code == 0
     print(result.output)
     assert '26f471f6ebe3b11557506f6ae96156e0a3852e5b' in result.output
     assert '809089' in result.output
 
-    result = runner.invoke(main, ['hashme', 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png', '-sc'])
+    result = runner.invoke(main, ['hashme', 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png', '-sc'])  # noqa
     assert result.exit_code == 0
     print(result.output)
     assert 'b61bad1cb3dfad6258bef11b12361effebe597a8c80131cd2d6d07fce2206243' in result.output
     assert '20d9c2bbdbaf669b' in result.output
 
+
 def test_json():
     runner = CliRunner()
-    result = runner.invoke(main, ["correct horse battery staple", "-j", "-m", "9cc2" ])
+    result = runner.invoke(main, ["correct horse battery staple", "-j", "-m", "9cc2"])
     assert result.exit_code == 0
     print(result.output)
     assert '"MD5": "9cc2ae8a1ba7a93da39b46fc1019c481"' in result.output


### PR DESCRIPTION
- `-c` for CRCs is kept, and works as expected with `-f`.
- Updated docs and provide a readme example.
- Add 1 TC with 2 checks.