### PR TITLE
Add new LENGTH digester & more fixes

### DIFF
--- a/omnihash/omnihash.py
+++ b/omnihash/omnihash.py
@@ -188,7 +188,7 @@ def make_digesters(families, include_CRCs=False):
 
     ## Append plugin digesters.
     digesters.update(known_digesters)
-    for digester in digesters.keys():
+    for digester in list(digesters.keys()):
         if not is_algo_in_families(digester.upper(), families):
             digesters.pop(digester, None)
 

--- a/omnihash/omnihash.py
+++ b/omnihash/omnihash.py
@@ -105,15 +105,16 @@ def main(click_context, hashmes, s, v, c, f, m, j):
             stdin = click.get_binary_stream('stdin')
             bytechunks = iter(lambda: stdin.read(io.DEFAULT_BUFFER_SIZE), b'')
             if not j:
-                click.echo("Hashing " + click.style("standard input", bold=True) + "..", err=True)
+                click.echo("Hashing " + click.style("standard input", bold=True) + "...", err=True)
             results = produce_hashes(bytechunks, digesters, match=m)
         else:
             print(click_context.get_help())
             return
     else:
+        hash_many = len(hashmes) > 1
         for hashme in hashmes:
             digesters = make_digesters(f, c)
-            bytechunks = iterate_bytechunks(hashme, s, j)
+            bytechunks = iterate_bytechunks(hashme, s, j, hash_many)
             if bytechunks:
                 results = produce_hashes(bytechunks, digesters, match=m, use_json=j)
 
@@ -121,7 +122,7 @@ def main(click_context, hashmes, s, v, c, f, m, j):
         print(json.dumps(results, indent=4, sort_keys=True))
 
 
-def iterate_bytechunks(hashme, is_string=True, use_json=False):
+def iterate_bytechunks(hashme, is_string, use_json, hash_many):
     """
     Prep our bytes.
     """
@@ -129,7 +130,7 @@ def iterate_bytechunks(hashme, is_string=True, use_json=False):
     # URL
     if not is_string and validators.url(hashme):
         if not use_json:
-            click.echo("Hashing content of URL " + click.style("{}".format(hashme), bold=True) + "..", err=True)
+            click.echo("Hashing content of URL " + click.style(hashme, bold=True) + "...", err=not hash_many)
         try:
             response = requests.get(hashme)
         except requests.exceptions.ConnectionError as e:
@@ -147,12 +148,12 @@ def iterate_bytechunks(hashme, is_string=True, use_json=False):
             return None
 
         if not use_json:
-            click.echo("Hashing file " + click.style("{}".format(hashme), bold=True) + "..", err=True)
+            click.echo("Hashing file " + click.style(hashme, bold=True) + "...", err=not hash_many)
         bytechunks = FileIter(open(hashme, mode='rb'))
     # String
     else:
         if not use_json:
-            click.echo("Hashing string " + click.style("{}".format(hashme), bold=True) + "..", err=True)
+            click.echo("Hashing string " + click.style(hashme, bold=True) + "...", err=not hash_many)
         bytechunks = (hashme.encode('utf-8'), )
 
     return bytechunks

--- a/omnihash/omnihash.py
+++ b/omnihash/omnihash.py
@@ -171,7 +171,7 @@ class LenDigester:
         self.length += len(b)
         
     def digest(self):
-        return self.length
+        return str(self.length)
 
 
 def make_digesters(families, include_CRCs=False):

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,7 @@
 from omnihash.omnihash import main
 import os
 import unittest
-import tempfile
+import sys
 
 import click
 from click.testing import CliRunner
@@ -47,6 +47,26 @@ class TOmnihash(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.exception)
         #print(result.output)
         self.assertIn('941c986ff0f3e90543dc5e2a0687ee99b19bff67', result.output)
+
+    @unittest.skipIf(sys.version_info[0] < 3, "unittest has no `assertRegex()`.")
+    def test_omnihashfile_length(self):
+        runner = CliRunner()
+
+        fpath = 'LICENSE'
+        text = 'hashme'
+        result = runner.invoke(main, [text, fpath])
+        self.assertEqual(result.exit_code, 0, result.exception)
+        self.assertRegex(result.output, r'LENGTH: +%i\D' % len(text))
+        filelen = os.stat(fpath).st_size
+        self.assertRegex(result.output, r'LENGTH: +%i\D' % filelen)
+
+    @unittest.skipIf(sys.version_info[0] < 3, "unittest has no `assertRegex()`.")
+    def test_omnihashfile_length_zero(self):
+        runner = CliRunner()
+
+        result = runner.invoke(main, [''])
+        self.assertEqual(result.exit_code, 0, result.exception)
+        self.assertRegex(result.output, r'LENGTH: +0\D')
 
     def test_omnihashf(self):
         runner = CliRunner()

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,113 +1,110 @@
 from omnihash.omnihash import main
+import os
 import unittest
+import tempfile
 
 import click
 from click.testing import CliRunner
 
 
-# Sanity
-def test_hello_world():
-    @click.command()
-    @click.argument('name')
-    def hello(name):
-        click.echo('Hello %s!' % name)
+class TOmnihash(unittest.TestCase):
 
-    runner = CliRunner()
-    result = runner.invoke(hello, ['Peter'])
-    assert result.exit_code == 0
-    assert result.output == 'Hello Peter!\n'
+    # Sanity
+    def test_hello_world(self):
+        @click.command()
+        @click.argument('name')
+        def hello(name):
+            click.echo('Hello %s!' % name)
 
+        runner = CliRunner()
+        result = runner.invoke(hello, ['Peter'])
+        self.assertEqual(result.exit_code, 0, result.exception)
+        self.assertEqual(result.output, 'Hello Peter!\n')
 
-# Main
-def test_empty():
-    runner = CliRunner()
-    result = runner.invoke(main)
-    print(result.output)
-    assert result.exit_code == 0
+    # Main
+    def test_empty(self):
+        runner = CliRunner()
+        result = runner.invoke(main)
+        print(result.output)
+        self.assertEqual(result.exit_code, 0, result.exception)
 
+    def test_omnihash(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ['hashme'])
+        print(result.output)
+        self.assertEqual(result.exit_code, 0, result.exception)
+        self.assertIn('fb78992e561929a6967d5328f49413fa99048d06', result.output)
 
-def test_omnihash():
-    runner = CliRunner()
-    result = runner.invoke(main, ['hashme'])
-    print(result.output)
-    assert result.exit_code == 0
-    assert 'fb78992e561929a6967d5328f49413fa99048d06' in result.output
+    def test_omnihash2(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ['hashme', 'asdf'])
+        self.assertEqual(result.exit_code, 0, result.exception)
+        self.assertIn('fb78992e561929a6967d5328f49413fa99048d06', result.output)
 
+    def test_omnihashfile(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ['hashme', 'LICENSE'])
+        self.assertEqual(result.exit_code, 0, result.exception)
+        #print(result.output)
+        self.assertIn('941c986ff0f3e90543dc5e2a0687ee99b19bff67', result.output)
 
-def test_omnihash2():
-    runner = CliRunner()
-    result = runner.invoke(main, ['hashme', 'asdf'])
-    assert result.exit_code == 0
-    assert 'fb78992e561929a6967d5328f49413fa99048d06' in result.output
-
-
-def test_omnihashfile():
-    runner = CliRunner()
-    result = runner.invoke(main, ['hashme', 'LICENSE'])
-    assert result.exit_code == 0
-    assert '941c986ff0f3e90543dc5e2a0687ee99b19bff67' in result.output
-
-
-def test_omnihashf():
-    runner = CliRunner()
-    result = runner.invoke(main, 'Hi -f sha2 -f SHA5'.split())
-    assert result.exit_code == 0
-    out = """
+    def test_omnihashf(self):
+        runner = CliRunner()
+        result = runner.invoke(main, 'Hi -f sha2 -f SHA5'.split())
+        self.assertEqual(result.exit_code, 0, result.exception)
+        out = """
   SHA224:                7d5104ff2cee331a4586337ea64ab6a188e2b26aecae87227105dae1
   SHA256:                3639efcd08abb273b1619e82e78c29a7df02c1051b1820e99fc395dcaa3326b8
-  SHA512:                45ca55ccaa72b98b86c697fdf73fd364d4815a586f76cd326f1785bb816ff7f1f88b46fb8448b19356ee788eb7d300\
-b9392709a289428070b5810d9b5c2d440d
+  SHA512:                45ca55ccaa72b98b86c697fdf73fd364d4815a586f76cd326f1785bb816ff7f1f88b46fb8448b19356ee\
+788eb7d300b9392709a289428070b5810d9b5c2d440d
 """
-    assert result.output.endswith(out)
+        assert result.output.endswith(out)
 
-    result = runner.invoke(main, 'Hi -c -f sha2 -c -f ITU'.split())
-    assert result.exit_code == 0
-    out = """
+        result = runner.invoke(main, 'Hi -c -f sha2 -c -f ITU'.split())
+        self.assertEqual(result.exit_code, 0, result.exception)
+        out = """
   SHA224:                7d5104ff2cee331a4586337ea64ab6a188e2b26aecae87227105dae1
   SHA256:                3639efcd08abb273b1619e82e78c29a7df02c1051b1820e99fc395dcaa3326b8
   CRC-8-ITU:             0xbe
 """
-    print(out)
-    assert result.output.endswith(out)
+        print(out)
+        assert result.output.endswith(out)
 
+    def test_omnihashs(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ['hashme', 'LICENSE', '-s'])
+        self.assertEqual(result.exit_code, 0, result.exception)
+        self.assertIn('0398ccd0f49298b10a3d76a47800d2ebecd49859', result.output)
 
-def test_omnihashs():
-    runner = CliRunner()
-    result = runner.invoke(main, ['hashme', 'LICENSE', '-s'])
-    assert result.exit_code == 0
-    assert '0398ccd0f49298b10a3d76a47800d2ebecd49859' in result.output
+    def test_omnihashcrc(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ['hashme', 'README.md', '-sc'])
+        self.assertEqual(result.exit_code, 0, result.exception)
+        print(result.output)
+        self.assertIn('fb78992e561929a6967d5328f49413fa99048d06', result.output)
+        self.assertIn('5d20a7c38be78000', result.output)
 
+    def test_url(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ['hashme', 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png', '-c'])    # noqa
+        self.assertEqual(result.exit_code, 0, result.exception)
+        print(result.output)
+        self.assertIn('26f471f6ebe3b11557506f6ae96156e0a3852e5b', result.output)
+        self.assertIn('809089', result.output)
 
-def test_omnihashcrc():
-    runner = CliRunner()
-    result = runner.invoke(main, ['hashme', 'README.md', '-sc'])
-    assert result.exit_code == 0
-    print(result.output)
-    assert 'fb78992e561929a6967d5328f49413fa99048d06' in result.output
-    assert '5d20a7c38be78000' in result.output
+        result = runner.invoke(main, ['hashme', 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png', '-sc'])  # noqa
+        self.assertEqual(result.exit_code, 0, result.exception)
+        print(result.output)
+        self.assertIn('b61bad1cb3dfad6258bef11b12361effebe597a8c80131cd2d6d07fce2206243', result.output)
+        self.assertIn('20d9c2bbdbaf669b', result.output)
 
+    def test_json(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["correct horse battery staple", "-j", "-m", "9cc2"])
+        self.assertEqual(result.exit_code, 0, result.exception)
+        print(result.output)
+        self.assertIn('"MD5": "9cc2ae8a1ba7a93da39b46fc1019c481"', result.output)
 
-def test_url():
-    runner = CliRunner()
-    result = runner.invoke(main, ['hashme', 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png', '-c'])    # noqa
-    assert result.exit_code == 0
-    print(result.output)
-    assert '26f471f6ebe3b11557506f6ae96156e0a3852e5b' in result.output
-    assert '809089' in result.output
-
-    result = runner.invoke(main, ['hashme', 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png', '-sc'])  # noqa
-    assert result.exit_code == 0
-    print(result.output)
-    assert 'b61bad1cb3dfad6258bef11b12361effebe597a8c80131cd2d6d07fce2206243' in result.output
-    assert '20d9c2bbdbaf669b' in result.output
-
-
-def test_json():
-    runner = CliRunner()
-    result = runner.invoke(main, ["correct horse battery staple", "-j", "-m", "9cc2"])
-    assert result.exit_code == 0
-    print(result.output)
-    assert '"MD5": "9cc2ae8a1ba7a93da39b46fc1019c481"' in result.output
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR contains an important bugfix, and required a new release: 
+ Families-check was modifying plugin-digesters while iterating.

Detailed changes:
+ Length of bytes-hashed are provided for each file as just another digester.
+ Send to stdout explanatory msgs about what is being hashed only when
  hashing multiple items.  The point is for script using `omnihash` to
  easily parse its output in the case of a single file, but still contain
  all necessary info in case it's input is being redirected in a log file
  and multiple files are hashed.
+ Retrofit all TCs as TestCase.methods, to easily view what's was the failing condition.
+ Added TCs for hash-length.
+ Now ALL TCs OK.