### PR TITLE
Add hashes for Git objects (blob/commit/tag)

### DIFF
--- a/omnihash/__init__.py
+++ b/omnihash/__init__.py
@@ -1,1 +1,5 @@
 __version__ = '0.11.0'
+__license__   = "MIT License"
+__title__     = "omnihash"
+__summary__ = "Hash files/strings/streams/network-resources simultaneously in various algorithms."
+__uri__ = "https://github.com/Miserlou/omnihash"

--- a/omnihash/omnihash.py
+++ b/omnihash/omnihash.py
@@ -76,7 +76,7 @@ class GitSlurpDigester:
 
     def digest(self):
         fsize = len(self.fbytes)
-        digester = hashlib.sha1(b"%s %i\0" % (self.otype, fsize))
+        digester = hashlib.sha1(("%s %i\0" % (self.otype, fsize)).encode())
         digester.update(self.fbytes)
         return digester.hexdigest()
 
@@ -91,9 +91,9 @@ def add_git_digesters(digesters, fpath):
     except:
         ## Failback to slurp-digesters `fpath` is not a file.
         #
-        digesters['GIT-BLOB'] = (GitSlurpDigester(b'blob'), lambda d: d.digest())
-        digesters['GIT-COMMIT'] = (GitSlurpDigester(b'commit'), lambda d: d.digest())
-        digesters['GIT-TAG'] = (GitSlurpDigester(b'tag'), lambda d: d.digest())
+        digesters['GIT-BLOB'] = (GitSlurpDigester('blob'), lambda d: d.digest())
+        digesters['GIT-COMMIT'] = (GitSlurpDigester('commit'), lambda d: d.digest())
+        digesters['GIT-TAG'] = (GitSlurpDigester('tag'), lambda d: d.digest())
 
 
 ##

--- a/omnihash/omnihash.py
+++ b/omnihash/omnihash.py
@@ -5,24 +5,22 @@
 from collections import OrderedDict
 import hashlib
 import io
-import itertools as itt
 import json
 import os
-import pkg_resources
 import sys
 
-# 3rd Party imports
 import click
+import pkg_resources
 import requests
 import validators
 
-# Algos
 import crcmod.predefined as crcmod
+import itertools as itt
+
 
 ##
 # Plugins
 ##
-
 PLUGIN_GROUP_NAME = 'omnihash.plugins'
 
 known_digesters = OrderedDict()
@@ -41,7 +39,7 @@ def intialize_plugins(plugin_group_name=PLUGIN_GROUP_NAME):
                        ep, ep.dist, ex), err=1)
 
 # Plugin algos
-def plugin_sha3_digesters(include_CRCs=False):
+def plugin_sha3_digesters():
     import sha3  # @UnresolvedImport
 
     known_digesters['SHA3_224'] = (sha3.SHA3224(), lambda d: d.hexdigest().decode("utf-8"))
@@ -50,11 +48,53 @@ def plugin_sha3_digesters(include_CRCs=False):
     known_digesters['SHA3_512'] = (sha3.SHA3512(), lambda d: d.hexdigest().decode("utf-8"))
 
 
-def plugin_pyblake2_digesters(include_CRCs=False):
+def plugin_pyblake2_digesters():
     import pyblake2  # @UnresolvedImport
 
     known_digesters['BLAKE2s'] = (pyblake2.blake2s(), lambda d: d.hexdigest())
     known_digesters['BLAKE2b'] = (pyblake2.blake2b(), lambda d: d.hexdigest())
+
+
+class GitSlurpDigester:
+    """
+    Produce Git-like hashes for bytes without knowing their size a priori.
+
+    Git SHA1-hashes the file-bytes prefixed with the filesize.
+    So when reading STDIN, we have to slurp the bytes to derive their length,
+    and hash them afterwards.
+
+    But it's not that we slurp multiple files, just the STDIN once.
+    """
+
+    fbytes = b''
+
+    def __init__(self, otype):
+        self.otype = otype
+
+    def update(self, fbytes):
+        self.fbytes += fbytes
+
+    def digest(self):
+        fsize = len(self.fbytes)
+        digester = hashlib.sha1(b"%s %i\0" % (self.otype, fsize))
+        digester.update(self.fbytes)
+        return digester.hexdigest()
+
+
+def add_git_digesters(digesters, fpath):
+    """Note that contrary to ``git hash-object`` no unix2dos EOL is done!"""
+    try:
+        fsize = os.stat(fpath).st_size
+        digesters['GIT-BLOB'] = (hashlib.sha1(b"blob %i\0" % fsize), lambda d: d.hexdigest())
+        digesters['GIT-COMMIT'] = (hashlib.sha1(b"commit %i\0" % fsize), lambda d: d.hexdigest())
+        digesters['GIT-TAG'] = (hashlib.sha1(b"tag %i\0" % fsize), lambda d: d.hexdigest())
+    except:
+        ## Failback to slurp-digesters `fpath` is not a file.
+        #
+        digesters['GIT-BLOB'] = (GitSlurpDigester(b'blob'), lambda d: d.digest())
+        digesters['GIT-COMMIT'] = (GitSlurpDigester(b'commit'), lambda d: d.digest())
+        digesters['GIT-TAG'] = (GitSlurpDigester(b'tag'), lambda d: d.digest())
+
 
 ##
 # Classes
@@ -75,6 +115,7 @@ class FileIter(object):
         except StopIteration:
             self._fd.close()
             raise
+
 
 class LenDigester:
     length = 0
@@ -118,7 +159,7 @@ def main(click_context, hashmes, s, v, c, f, m, j):
     if not hashmes:
         # If no stdin, just help and quit.
         if not sys.stdin.isatty():
-            digesters = make_digesters(f, c)
+            digesters = make_digesters(None, f, c)
             stdin = click.get_binary_stream('stdin')
             bytechunks = iter(lambda: stdin.read(io.DEFAULT_BUFFER_SIZE), b'')
             if not j:
@@ -130,13 +171,14 @@ def main(click_context, hashmes, s, v, c, f, m, j):
     else:
         hash_many = len(hashmes) > 1
         for hashme in hashmes:
-            digesters = make_digesters(f, c)
+            digesters = make_digesters(hashme, f, c)
             bytechunks = iterate_bytechunks(hashme, s, j, hash_many)
             if bytechunks:
                 results = produce_hashes(bytechunks, digesters, match=m, use_json=j)
 
     if results and j:
         print(json.dumps(results, indent=4, sort_keys=True))
+
 
 ##
 # Main Logic
@@ -179,7 +221,7 @@ def iterate_bytechunks(hashme, is_string, use_json, hash_many):
     return bytechunks
 
 
-def make_digesters(families, include_CRCs=False):
+def make_digesters(fpath, families, include_CRCs=False):
     """
     Create and return a dictionary of all our active hash algorithms.
 
@@ -208,7 +250,10 @@ def make_digesters(families, include_CRCs=False):
                 digesters[aname] = (crcmod.PredefinedCrc(crc_name),
                                     lambda d: hex(d.crcValue))
 
+    add_git_digesters(digesters, fpath)
+
     ## Append plugin digesters.
+    #
     digesters.update(known_digesters)
     for digester in list(digesters.keys()):
         if not is_algo_in_families(digester.upper(), families):
@@ -248,6 +293,7 @@ def produce_hashes(bytechunks, digesters, match, use_json=False):
                 click.echo(click.style("No matches", fg='red') + " found!", err=True)
 
     return results
+
 
 ##
 # Util

--- a/setup.py
+++ b/setup.py
@@ -66,4 +66,10 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     tests_require=['nose'],
+    options={
+        'bdist_wheel': {
+            'universal': True,
+        },
+    },
+    platforms=['any'],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
+import io
 import os
-import sys
 
 from setuptools import setup
 import setuptools
 
-import omnihash
 
 # To support 2/3 installation
 setup_version = int(setuptools.__version__.split('.')[0])
@@ -13,12 +12,25 @@ if setup_version < 18:
     print("pip install -U pip wheel setuptools")
     quit()
 
+mydir = os.path.dirname(__file__)
+
 # Set external files
 try:
     from pypandoc import convert
     README = convert('README.md', 'rst')
 except ImportError:
     README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
+
+
+## Version-trick to have version-info in a single place, taken from:
+# http://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package
+#
+def read_project_version():
+    fglobals = {}
+    with io.open(os.path.join(
+            mydir, 'omnihash', '__init__.py'), encoding='UTF-8') as fd:
+        exec(fd.read(), fglobals)  # To read __version__
+    return fglobals['__version__']
 
 with open(os.path.join(os.path.dirname(__file__), 'requirements.txt')) as f:
     required = [l for l in f.read().splitlines()  # Exclude extras.
@@ -29,7 +41,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='omnihash',
-    version=omnihash.__version__,
+    version=read_project_version(),
     packages=['omnihash'],
     install_requires=required,
     include_package_data=True,
@@ -66,6 +78,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     tests_require=['nose'],
+    zip_safe=True,
     options={
         'bdist_wheel': {
             'universal': True,

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,6 +7,14 @@ import click
 from click.testing import CliRunner
 
 
+def safe_str(obj):
+    try:
+        s = str(obj)
+    except Exception as ex:
+        s = ex
+    return s
+
+
 class TOmnihash(unittest.TestCase):
 
     # Sanity
@@ -17,42 +25,42 @@ class TOmnihash(unittest.TestCase):
             click.echo('Hello %s!' % name)
 
         runner = CliRunner()
-        result = runner.invoke(hello, ['Peter'])
-        self.assertEqual(result.exit_code, 0, result.exception)
+        result = runner.invoke(hello, ['Peter'], catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, 'Hello Peter!\n')
 
     # Main
     def test_empty(self):
         runner = CliRunner()
-        result = runner.invoke(main)
+        result = runner.invoke(main, catch_exceptions=False)
         print(result.output)
-        self.assertEqual(result.exit_code, 0, result.exception)
+        self.assertEqual(result.exit_code, 0)
 
     def test_omnihash(self):
         runner = CliRunner()
-        result = runner.invoke(main, ['hashme'])
+        result = runner.invoke(main, ['hashme'], catch_exceptions=False)
         print(result.output)
-        self.assertEqual(result.exit_code, 0, result.exception)
+        self.assertEqual(result.exit_code, 0)
         self.assertIn('fb78992e561929a6967d5328f49413fa99048d06', result.output)
 
     def test_omnihash2(self):
         runner = CliRunner()
-        result = runner.invoke(main, ['hashme', 'asdf'])
-        self.assertEqual(result.exit_code, 0, result.exception)
+        result = runner.invoke(main, ['hashme', 'asdf'], catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
         self.assertIn('fb78992e561929a6967d5328f49413fa99048d06', result.output)
 
     def test_omnihashfile(self):
         runner = CliRunner()
-        result = runner.invoke(main, ['hashme', 'LICENSE'])
-        self.assertEqual(result.exit_code, 0, result.exception)
+        result = runner.invoke(main, ['hashme', 'LICENSE'], catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
         #print(result.output)
         self.assertIn('941c986ff0f3e90543dc5e2a0687ee99b19bff67', result.output)
 
     def test_omnihashfile_conjecutive(self):
         import re
         runner = CliRunner()
-        result = runner.invoke(main, 'LICENSE LICENSE -f sha1'.split())
-        self.assertEqual(result.exit_code, 0, result.exception)
+        result = runner.invoke(main, 'LICENSE LICENSE -f sha1'.split(), catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
         #print(result.output)
         matches = re.findall('941c986ff0f3e90543dc5e2a0687ee99b19bff67', result.output)
         self.assertEqual(len(matches), 4)
@@ -63,8 +71,8 @@ class TOmnihash(unittest.TestCase):
 
         fpath = 'LICENSE'
         text = 'hashme'
-        result = runner.invoke(main, [text, fpath])
-        self.assertEqual(result.exit_code, 0, result.exception)
+        result = runner.invoke(main, [text, fpath], catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
         self.assertRegex(result.output, r'LENGTH: +%i\D' % len(text))
         filelen = os.stat(fpath).st_size
         self.assertRegex(result.output, r'LENGTH: +%i\D' % filelen)
@@ -73,14 +81,14 @@ class TOmnihash(unittest.TestCase):
     def test_omnihashfile_length_zero(self):
         runner = CliRunner()
 
-        result = runner.invoke(main, [''])
-        self.assertEqual(result.exit_code, 0, result.exception)
+        result = runner.invoke(main, [''], catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
         self.assertRegex(result.output, r'LENGTH: +0\D')
 
     def test_omnihashf(self):
         runner = CliRunner()
-        result = runner.invoke(main, 'Hi -f sha2 -f SHA5'.split())
-        self.assertEqual(result.exit_code, 0, result.exception)
+        result = runner.invoke(main, 'Hi -f sha2 -f SHA5'.split(), catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
         out = """
   SHA224:                7d5104ff2cee331a4586337ea64ab6a188e2b26aecae87227105dae1
   SHA256:                3639efcd08abb273b1619e82e78c29a7df02c1051b1820e99fc395dcaa3326b8
@@ -89,8 +97,8 @@ class TOmnihash(unittest.TestCase):
 """
         assert result.output.endswith(out)
 
-        result = runner.invoke(main, 'Hi -c -f sha2 -c -f ITU'.split())
-        self.assertEqual(result.exit_code, 0, result.exception)
+        result = runner.invoke(main, 'Hi -c -f sha2 -c -f ITU'.split(), catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
         out = """
   SHA224:                7d5104ff2cee331a4586337ea64ab6a188e2b26aecae87227105dae1
   SHA256:                3639efcd08abb273b1619e82e78c29a7df02c1051b1820e99fc395dcaa3326b8
@@ -101,14 +109,14 @@ class TOmnihash(unittest.TestCase):
 
     def test_omnihashs(self):
         runner = CliRunner()
-        result = runner.invoke(main, ['hashme', 'LICENSE', '-s'])
-        self.assertEqual(result.exit_code, 0, result.exception)
+        result = runner.invoke(main, ['hashme', 'LICENSE', '-s'], catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
         self.assertIn('0398ccd0f49298b10a3d76a47800d2ebecd49859', result.output)
 
     def test_omnihashcrc(self):
         runner = CliRunner()
-        result = runner.invoke(main, ['hashme', 'README.md', '-sc'])
-        self.assertEqual(result.exit_code, 0, result.exception)
+        result = runner.invoke(main, ['hashme', 'README.md', '-sc'], catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
         print(result.output)
         self.assertIn('fb78992e561929a6967d5328f49413fa99048d06', result.output)
         self.assertIn('5d20a7c38be78000', result.output)
@@ -116,28 +124,28 @@ class TOmnihash(unittest.TestCase):
     def test_url(self):
         runner = CliRunner()
         result = runner.invoke(main, ['hashme', 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png', '-c'])    # noqa
-        self.assertEqual(result.exit_code, 0, result.exception)
+        self.assertEqual(result.exit_code, 0)
         print(result.output)
         self.assertIn('26f471f6ebe3b11557506f6ae96156e0a3852e5b', result.output)
         self.assertIn('809089', result.output)
 
         result = runner.invoke(main, ['hashme', 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png', '-sc'])  # noqa
-        self.assertEqual(result.exit_code, 0, result.exception)
+        self.assertEqual(result.exit_code, 0)
         print(result.output)
         self.assertIn('b61bad1cb3dfad6258bef11b12361effebe597a8c80131cd2d6d07fce2206243', result.output)
         self.assertIn('20d9c2bbdbaf669b', result.output)
 
     def test_json(self):
         runner = CliRunner()
-        result = runner.invoke(main, ["correct horse battery staple", "-j", "-m", "9cc2"])
-        self.assertEqual(result.exit_code, 0, result.exception)
+        result = runner.invoke(main, ["correct horse battery staple", "-j", "-m", "9cc2"], catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
         print(result.output)
         self.assertIn('"MD5": "9cc2ae8a1ba7a93da39b46fc1019c481"', result.output)
 
     def test_omnihashfile_git(self):
         runner = CliRunner()
-        result = runner.invoke(main, 'LICENSE -f git'.split())
-        self.assertEqual(result.exit_code, 0, result.exception)
+        result = runner.invoke(main, 'LICENSE -f git'.split(), catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
         #print(result.output)
         self.assertIn('3e108735fcf3efac2b181874a34861a9fb5e7cc1', result.output)
         self.assertIn('25063c5229e9e558e3207413a1fa56c6262eedc2', result.output)

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,7 @@
 from omnihash.omnihash import main
 import os
-import unittest
 import sys
+import unittest
 
 import click
 from click.testing import CliRunner
@@ -47,6 +47,15 @@ class TOmnihash(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.exception)
         #print(result.output)
         self.assertIn('941c986ff0f3e90543dc5e2a0687ee99b19bff67', result.output)
+
+    def test_omnihashfile_conjecutive(self):
+        import re
+        runner = CliRunner()
+        result = runner.invoke(main, 'LICENSE LICENSE -f sha1'.split())
+        self.assertEqual(result.exit_code, 0, result.exception)
+        #print(result.output)
+        matches = re.findall('941c986ff0f3e90543dc5e2a0687ee99b19bff67', result.output)
+        self.assertEqual(len(matches), 4)
 
     @unittest.skipIf(sys.version_info[0] < 3, "unittest has no `assertRegex()`.")
     def test_omnihashfile_length(self):
@@ -125,6 +134,14 @@ class TOmnihash(unittest.TestCase):
         print(result.output)
         self.assertIn('"MD5": "9cc2ae8a1ba7a93da39b46fc1019c481"', result.output)
 
+    def test_omnihashfile_git(self):
+        runner = CliRunner()
+        result = runner.invoke(main, 'LICENSE -f git'.split())
+        self.assertEqual(result.exit_code, 0, result.exception)
+        #print(result.output)
+        self.assertIn('3e108735fcf3efac2b181874a34861a9fb5e7cc1', result.output)
+        self.assertIn('25063c5229e9e558e3207413a1fa56c6262eedc2', result.output)
+        self.assertIn('2c97833c235648e752a00f8ef709fbe2f3523ca4', result.output)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Generate hashes as ``git hash-object <file`` cmd would do, but...
- without converting EOL on textual-files (no binary detection).
- Also support <STDIN>.
- Sample output (in this case, only the 1st line has meaning):
  ```
  $ omnihash LICENSE  -f git
  Hashing file LICENSE...
    GIT-BLOB:              3e108735fcf3efac2b181874a34861a9fb5e7cc1
    GIT-COMMIT:            25063c5229e9e558e3207413a1fa56c6262eedc2
    GIT-TAG:               2c97833c235648e752a00f8ef709fbe2f3523ca4
  ```
- Other  changes: mark distribution-wheel as `zip_safe` since now reading version without [importing the package itself](http://stackoverflow.com/a/2073599/548792).
- Add project's coords as package special attributes ``__URI__, __SUMMARY__,`` etc.